### PR TITLE
Update genomes-in-the-cloud to a docker supported version

### DIFF
--- a/cram2filtered.trigger.json
+++ b/cram2filtered.trigger.json
@@ -1,6 +1,6 @@
 {
-  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/gatk4-cnn-variant-filter-azure/az1.2.0/cram2filtered.wdl",
-  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/gatk4-cnn-variant-filter-azure/az1.2.0/cram2filtered.inputs.json", 
+  "WorkflowUrl": "https://raw.githubusercontent.com/microsoft/gatk4-cnn-variant-filter-azure/main-azure/cram2filtered.wdl",
+  "WorkflowInputsUrl": "https://raw.githubusercontent.com/microsoft/gatk4-cnn-variant-filter-azure/main-azure/cram2filtered.inputs.json", 
   "WorkflowOptionsUrl": null,
   "WorkflowDependenciesUrl": null
 }

--- a/cram2filtered.wdl
+++ b/cram2filtered.wdl
@@ -12,7 +12,7 @@
 
 #import "cnn_variant_common_tasks.wdl" as CNNTasks
 
-import "https://raw.githubusercontent.com/microsoft/gatk4-cnn-variant-filter-azure/az1.2.0/tasks/cnn_variant_common_tasks.wdl" as CNNTasks
+import "https://raw.githubusercontent.com/microsoft/gatk4-cnn-variant-filter-azure/main-azure/tasks/cnn_variant_common_tasks.wdl" as CNNTasks
 
 workflow Cram2FilteredVcf {
     File input_file                  # Aligned CRAM file or Aligned BAM files

--- a/tasks/cnn_variant_common_tasks.wdl
+++ b/tasks/cnn_variant_common_tasks.wdl
@@ -317,7 +317,7 @@ command <<<
   echo "ls (4): complete"
   >>>
   runtime {
-    docker: "broadinstitute/genomes-in-the-cloud:2.1.1"
+    docker: "broadinstitute/genomes-in-the-cloud:2.3.1-1512499786"
     memory: machine_mem + " MB"
     disk: disk_space_gb + " GB"
     preemptible: true
@@ -346,7 +346,7 @@ task SamtoolsMergeBAMs {
     }
 
   runtime {
-    docker: "broadinstitute/genomes-in-the-cloud:2.1.1"
+    docker: "broadinstitute/genomes-in-the-cloud:2.3.1-1512499786"
     memory: "16 GB"
     disk: disk_space_gb + " GB"
   }


### PR DESCRIPTION
Alternately, create new tag to use in workflows (which includes the changes in `tasks/cnn_variant_common_tasks.wdl`.

Needed to unblock workflows in CoA